### PR TITLE
Add field tx_id to invoice form

### DIFF
--- a/addons/account/views/account_invoice_view.xml
+++ b/addons/account/views/account_invoice_view.xml
@@ -442,6 +442,7 @@
                         </div>
                     </h1>
                     <field name="type" invisible="1"/>
+                    <field name="tx_id" invisible="1"/>
                     <group>
                         <group>
                             <field string="Customer" name="partner_id"


### PR DESCRIPTION
Desired behavior after PR is merged:
Add an invisible field `tx_id` to the invoice form so that the `read` request passes it as a parameter to the server.
